### PR TITLE
Fix Chatbot prop name

### DIFF
--- a/src/components/ChatBot/ChatBot.jsx
+++ b/src/components/ChatBot/ChatBot.jsx
@@ -17,8 +17,8 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CloseIcon from "@mui/icons-material/Close";
 import { chatBotModel } from "./chatBotModel";
 
-export default function Chatbot(theme) {
-  let mode = theme;
+export default function Chatbot({ theme }) {
+  const mode = theme;
   const [messages, setMessages] = useState([
     {
       id: 1, // Added a unique ID for each message

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -29,7 +29,7 @@ export default function Home({ theme }) {
         <Projects />
         <Contact />
         <Footer theme={mode} />
-        <Chatbot them={mode} />
+        <Chatbot theme={mode} />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- update Chatbot component to accept a `theme` prop
- fix Home page to pass the correct prop name

## Testing
- `npm run build` *(fails: Cannot find module 'dotenv/config')*

------
https://chatgpt.com/codex/tasks/task_e_684804fec290832896f951acbc900f5b